### PR TITLE
Fixed Remove method of element

### DIFF
--- a/BinarySearchTree/BST.cpp
+++ b/BinarySearchTree/BST.cpp
@@ -1,4 +1,4 @@
-#include"BST.h"
+#include "BST.h"
 #include<stdexcept>
 
 
@@ -128,26 +128,26 @@ DataType* BST::Search(Node* root,const KeyType& key) {
 
 
 void BST::Remove(const KeyType& key) {
-
-	Remove(root, key);
+	Node* null = nullptr;
+	Remove(root,null, key);
 
 }
 
-void BST::Remove(Node*& root,const KeyType& key) {
+void BST::Remove(Node*& root,Node*& last,const KeyType& key) {
 
 	//search phase
-	
+
 	//there isn't elem with key "key"
 	if (root == nullptr)
 		return; //can be exception or std::err , or std::cout
 
 	if (key > root->Key) {
-		Remove(root->pRight, key);
+		Remove(root->pRight,root, key);
 		return;
 	}
 
 	if (key < root->Key) {
-		Remove(root->pLeft, key);
+		Remove(root->pLeft,root, key);
 		return;
 	}
 
@@ -167,13 +167,23 @@ void BST::Remove(Node*& root,const KeyType& key) {
 		root->Key = tmp->Key;
 
 		//removing the switched elem
-		Remove(root->pLeft, root->Key);
+		Remove(root->pLeft,root, root->Key);
 
 
 	}
 	else {  //one child or none
-
+		
 		if (root->pLeft) {
+			if (root->pLeft->pLeft||root->pLeft->pRight)
+			{
+				Node* temp = root;
+				last->pLeft = root->pLeft;
+
+				delete[] temp;
+				temp = nullptr;
+
+				return;
+			}
 
 			root->Data = root->pLeft->Data;
 			root->Key = root->pLeft->Key;
@@ -182,6 +192,16 @@ void BST::Remove(Node*& root,const KeyType& key) {
 		}
 
 		if (root->pRight) {
+			if (root->pRight->pLeft || root->pRight->pRight)
+			{
+				Node* temp = root;
+				last->pRight = root->pRight;
+
+				delete[] temp;
+				temp = nullptr;
+
+				return;
+			}
 
 			root->Data = root->pRight->Data;
 			root->Key = root->pRight->Key;

--- a/BinarySearchTree/BST.h
+++ b/BinarySearchTree/BST.h
@@ -45,7 +45,7 @@ private:
 
 	DataType* Search(Node*,const KeyType&);
 
-	void Remove(Node*&,const KeyType&);
+	void Remove(Node*&,Node*&,const KeyType&);
 
 	
 


### PR DESCRIPTION
Extend the method with one more parameter to remember the previous root.
After found biggest element with only one heir, check it if he has more heirs. If he has , create temporary node and give him the address of element to remove. Then just connect the ancestor with the next heir and delete the temporary node and make it nullptr.